### PR TITLE
Allow quoting map keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,41 @@ const result = sass.compile(scssFilename, {
 });
 ```
 
+## Stringify keys in a map
+
+By default, in a map all keys are imported unstringified.
+
+A json file:
+
+```json
+{
+	"red": "#c33",
+	"bee-yellow": "#fdfd00"
+}
+```
+
+will be imported as scss:
+
+```scss
+$colors: (
+	red: #c33,
+	beeYellow: #fdfd00,
+);
+```
+
+In the scss map above `red` is a color, while `beeYellow` is a string.
+
+`stringifyKeys: true` can be used to stringify all keys in a map.
+
+When `stringifyKeys: true`, the following scss map will be imported for the json example from above:
+
+```scss
+$colors: (
+	'red': #c33,
+	'beeYellow': #fdfd00,
+);
+```
+
 ## Acknowledgements
 
 This module is based on the original [node-sass-json-importer](https://www.npmjs.com/package/node-sass-json-importer) and the [sass-json-importer](https://github.com/neild3r/sass-json-importer). Unfortunately, neither handles WordPress's theme.json file correctly.

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -18,7 +18,7 @@ interface ImporterOptions {
 	/**
 	 * If `true`, will stringify sass map keys.
 	 *
-	 * In sass some values, such as color names (`red`), look like unquoted strings but are actually other types.
+	 * In sass some values, such as color names (e.g. `red`), look like unquoted strings but are actually other types.
 	 *
 	 * When a key is not a string, it can only be accessed in a map by its value.
 	 *
@@ -26,6 +26,11 @@ interface ImporterOptions {
 	 *
 	 * - `map.get($values, red)` returns `#c33`
 	 * - `map.get($values, "red")` returns `null`
+	 *
+	 * Because `red` is an html color.
+	 *
+	 * Both `map.get($values, beeYellow)` and `map.get($values, "beeYellow")` return `#fdfd00`.
+	 * Because `beeYellow` is not an html color.
 	 */
 	stringifyKeys?: boolean;
 }

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -14,24 +14,6 @@ interface ImporterOptions {
 	loadPaths?: string[];
 	convertCase?: boolean;
 	resolveWordPressInternals?: boolean;
-
-	/**
-	 * If `true`, will stringify sass map keys.
-	 *
-	 * In sass some values, such as color names (e.g. `red`), look like unquoted strings but are actually other types.
-	 *
-	 * When a key is not a string, it can only be accessed in a map by its value.
-	 *
-	 * Example: for a map: `$values: (red: #c33, beeYellow: #fdfd00)`
-	 *
-	 * - `map.get($values, red)` returns `#c33`
-	 * - `map.get($values, "red")` returns `null`
-	 *
-	 * Because `red` is an html color.
-	 *
-	 * Both `map.get($values, beeYellow)` and `map.get($values, "beeYellow")` return `#fdfd00`.
-	 * Because `beeYellow` is not an html color.
-	 */
 	stringifyKeys?: boolean;
 }
 

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -168,7 +168,7 @@ export default class JsonImporter implements Importer {
 	}
 
 	protected parseMap(jsonContent: JsonObject) {
-		return `(${this.processKeys(jsonContent, (key, value) => `${key}: ${this.parseValue(value)}`).join(',')})`;
+		return `(${this.processKeys(jsonContent, (key, value) => `"${key}": ${this.parseValue(value)}`).join(',')})`;
 	}
 
 	protected parseList(list: JsonValue[]) {

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -14,6 +14,20 @@ interface ImporterOptions {
 	loadPaths?: string[];
 	convertCase?: boolean;
 	resolveWordPressInternals?: boolean;
+
+	/**
+	 * If `true`, will stringify sass map keys.
+	 *
+	 * In sass some values, such as color names (`red`), look like unquoted strings but are actually other types.
+	 *
+	 * When a key is not a string, it can only be accessed in a map by its value.
+	 *
+	 * Example: for a map: `$values: (red: #c33, beeYellow: #fdfd00)`
+	 *
+	 * - `map.get($values, red)` returns `#c33`
+	 * - `map.get($values, "red")` returns `null`
+	 */
+	stringifyKeys?: boolean;
 }
 
 type JsonValue = string | number | boolean | null;
@@ -168,7 +182,11 @@ export default class JsonImporter implements Importer {
 	}
 
 	protected parseMap(jsonContent: JsonObject) {
-		return `(${this.processKeys(jsonContent, (key, value) => `"${key}": ${this.parseValue(value)}`).join(',')})`;
+		return `(${this.processKeys(jsonContent, (key, value) => {
+			let mapKey = this.options.stringifyKeys ? `"${key}"` : key;
+
+			return `${mapKey}: ${this.parseValue(value)}`;
+		}).join(',')})`;
 	}
 
 	protected parseList(list: JsonValue[]) {

--- a/src/tests/importer.type-json.test.ts
+++ b/src/tests/importer.type-json.test.ts
@@ -64,10 +64,9 @@ describe('Import type test (JSON)', () => {
 
 	it('imports maps', async () => {
 		const result = await compiler.compileStringAsync(
-			`@use 'sass:map'; @import "maps.json"; body { color: map.get($colors, "red"); }`,
+			`@use 'sass:map'; @import "maps.json"; body { color: map.get($colors, red); }`,
 			sassOptions,
 		);
-
 		expect(result.css.toString()).toContain(expectedResult);
 	});
 

--- a/src/tests/importer.type-json.test.ts
+++ b/src/tests/importer.type-json.test.ts
@@ -70,6 +70,24 @@ describe('Import type test (JSON)', () => {
 		expect(result.css.toString()).toContain(expectedResult);
 	});
 
+	it('with stringifyKeys: true, imports maps with quoted keys', async () => {
+		let jsonImporter = new JsonImporter({
+			loadPaths: ['./src/tests/fixtures'],
+			stringifyKeys: true,
+		});
+
+		let options = {
+			importers: [jsonImporter],
+		};
+
+		const result = await compiler.compileStringAsync(
+			`@use 'sass:map'; @import "maps.json"; body { color: map.get($colors, "red"); }`,
+			options,
+		);
+
+		expect(result.css.toString()).toContain(expectedResult);
+	});
+
 	it('imports maps with array as top level', async () => {
 		const result = await compiler.compileStringAsync(
 			`@use 'sass:list'; @import "array.json"; body { color: list.nth($array, 1); }`,

--- a/src/tests/importer.type-json.test.ts
+++ b/src/tests/importer.type-json.test.ts
@@ -64,9 +64,10 @@ describe('Import type test (JSON)', () => {
 
 	it('imports maps', async () => {
 		const result = await compiler.compileStringAsync(
-			`@use 'sass:map'; @import "maps.json"; body { color: map.get($colors, red); }`,
+			`@use 'sass:map'; @import "maps.json"; body { color: map.get($colors, "red"); }`,
 			sassOptions,
 		);
+
 		expect(result.css.toString()).toContain(expectedResult);
 	});
 


### PR DESCRIPTION
In SCSS map, keys can be both string and non-string values.

When a key is a string, the value can be accessed via both quoted and unquoted strings.

When a key is not a string (color `red`), the value can only be accessed by its key (color `red`, not `"red"`).

Example ([playground](https://sass-lang.com/playground/#eJx9kcEOgjAQRO/9ik31AAkagRtcjH/hEeiCxEqVtjFq/HcXUINSPXY6b2azG4ZrqxG4zrRODtmRp4zNCyVVqxPwWhQJzIo4DkDW1c5spEUSsqIMIEfcopTqTEIpSrFa+ekLjYjlBPOBpg+2FpjbCjhhi0vPgXeyyqDwOVDxskLjPfGgtw3pnOAp60DexLiNZvhb0804KuieUxep35nR79TIGQuRy/hMXhrUBm4MoFSNWej6SlsOWzykJPXmxDH7+yJdFUCeFfuqVbYRLvPHPu/sAYGzndo=)):

```scss
@use "sass:map";

$colors: (red: #c33, beeYellow: #fdfd00);

@debug "bee-yellow (quoted)" map.get($colors, "beeYellow"); // prints "bee-yellow (quoted)" #fdfd00
@debug "bee-yellow" map.get($colors, beeYellow); // prints "bee-yellow" #fdfd00

@debug "red (quoted)" map.get($colors, "red"); // prints "red (quoted)" null
@debug "red" map.get($colors, red); // prints "red" #c33
```

> Most of the time, it’s a good idea to use quoted strings rather than unquoted strings for map keys. 
> This is because some values, such as color names, may look like unquoted strings but actually be other types. 
> To avoid confusing problems down the line, just use quotes!
>
> _from [Sass: Maps (sass-lang.com)](https://sass-lang.com/documentation/values/maps/)_

# In this PR

Add `stringifyKeys` option to turn all map keys into strings in generated scss.

Add a test.
